### PR TITLE
Convert dipu9621033/dipu to GitHub Actions

### DIFF
--- a/.github/workflows/dipu.yml
+++ b/.github/workflows/dipu.yml
@@ -1,0 +1,19 @@
+name: dipu9621033/dipu
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  checkout_code:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Checking out the code..."
+    - run: git status


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/dipu9621033/dipu) :tada: